### PR TITLE
Update for AWS Quickstart templates for SIOS Protection Suite for Linux version 9.8.1

### DIFF
--- a/scripts/InstallLicAndStartLK.pl
+++ b/scripts/InstallLicAndStartLK.pl
@@ -22,6 +22,7 @@ use vars qw($opt_u $opt_s $opt_r);
 my $DEFAULT_LIC_NAME = "/evalkeys.lic";
 my $ret;
 my $licenseURL;
+my $AMIType;
 
 #
 # Usage
@@ -39,6 +40,11 @@ sub usage {
 sub lookupLicenseParameter {
     $licenseURL = `/usr/local/bin/aws cloudformation describe-stacks --stack-name $opt_s --region $opt_r | /usr/local/bin/jq '.Stacks[0].Parameters[] | select(.ParameterKey=="SIOSLicenseKeyFtpURL") | .ParameterValue' | sed 's/"//g'`;
     chomp($licenseURL);
+}
+
+sub lookupAMITypeParameter {
+	$AMIType = `/usr/local/bin/aws cloudformation describe-stacks --stack-name $opt_s --region $opt_r | /usr/local/bin/jq '.Stacks[0].Parameters[0] | select(.ParameterKey="SIOSAMIType") | .ParameterValue' | sed 's/"//g'`;
+	chomp($AMIType);	
 }
 
 #
@@ -217,17 +223,29 @@ if ($opt_u eq '') {
     $licenseURL = $opt_u;
 }
 
+lookupAMITypeParameter();
+
+# Is LK Started (1 = no, 0 = yes)
 $ret = CheckLKStatus();
 if (!$ret) {
     # LifeKeeper is not running so assume we need to retrieve the license,
     # install it and then start LifeKeeper.
     my $licFile = GetLicenseFile();
+
+    my $installedLicenseFileRet=0;
     if (!defined $licFile) {
-        exit 1;
+        # No license file found, fail unless we can start LifeKeeper
+        $ret=1;
+    }else{
+        $installedLicenseFileRet = InstallLicense($licFile);
     }
-    if (InstallLicense($licFile)) {
-        $ret = !(StartLifeKeeper());
+    if ( $AMIType eq "PAYG" || $installedLicenseFileRet ) {
+	    $ret = !(StartLifeKeeper());
     }
+}else{
+	# LifeKeeper is started
+	# Assume we have a license and continue with stack creation
+	$ret = 0;
 }
 
 exit $ret;

--- a/templates/sios-protection-suite.template.yaml
+++ b/templates/sios-protection-suite.template.yaml
@@ -402,50 +402,50 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     ap-northeast-2:
-      SPSLRHEL: ami-0d016e528c71c0ee0
-      SPSLRHELBYOL: ami-0b9201d63255cb5cf
+      SPSLRHEL: ami-0702f9831a8afc6b6
+      SPSLRHELBYOL: ami-0ffae71f35046f924
     ap-south-1:
-      SPSLRHEL: ami-013d40db52efcd272
-      SPSLRHELBYOL: ami-07056e985655d39dc
+      SPSLRHEL: ami-085441ad7b3bfa29e
+      SPSLRHELBYOL: ami-04836e1d837406afd
     ap-southeast-1:
-      SPSLRHEL: ami-06bc9190c4d1a9c1f
-      SPSLRHELBYOL: ami-062396fefaffee5b8
+      SPSLRHEL: ami-02d67eda42967b2c6
+      SPSLRHELBYOL: ami-0652c3f21cffb1d12
     ap-southeast-2:
-      SPSLRHEL: ami-05e5acc8eb5d52b0f
-      SPSLRHELBYOL: ami-0fd2d06e9757a2003
+      SPSLRHEL: ami-0a0415561fddd877d
+      SPSLRHELBYOL: ami-0a3bfc8c2cfb41e76
     ca-central-1:
-      SPSLRHEL: ami-0d5c54f2e718af8be
-      SPSLRHELBYOL: ami-095644403b5fd5581
+      SPSLRHEL: ami-0c33e2c0e7eba971c
+      SPSLRHELBYOL: ami-004882e4c793779aa
     eu-central-1:
-      SPSLRHEL: ami-09491fdbec81caccf
-      SPSLRHELBYOL: ami-0944551716698acfd
+      SPSLRHEL: ami-0c2dfa2598531a1e2
+      SPSLRHELBYOL: ami-09230c5b285627aca
     eu-north-1:
-      SPSLRHEL: ami-037ef075742bf4343
-      SPSLRHELBYOL: ami-0bb0dbf26654d51cb
+      SPSLRHEL: ami-054bfc21d64b467fc
+      SPSLRHELBYOL: ami-02b256aa6261c90df
     eu-west-1:
-      SPSLRHEL: ami-03d1efaef90eb309b
-      SPSLRHELBYOL: ami-0dad48da97e9ab37d
+      SPSLRHEL: ami-08193987e940507f3
+      SPSLRHELBYOL: ami-0d84193ac1e2070f1
     eu-west-2:
-      SPSLRHEL: ami-02ae9d981572da5cd
-      SPSLRHELBYOL: ami-03e661bb8b3105cb2
+      SPSLRHEL: ami-0e175456fa6bcb7ee
+      SPSLRHELBYOL: ami-095b07555e5f6fcaf
     eu-west-3:
-      SPSLRHEL: ami-0212a22bd7f649252
-      SPSLRHELBYOL: ami-0e089a53a16e9a879
+      SPSLRHEL: ami-0c59411bf087a77bc
+      SPSLRHELBYOL: ami-0ec5a3cc726b24e18
     sa-east-1:
-      SPSLRHEL: ami-0cb2883a76e7eff6c
-      SPSLRHELBYOL: ami-048e86bddb10570de
+      SPSLRHEL: ami-0b5e8f29776704600
+      SPSLRHELBYOL: ami-0169c29a58abbeafa
     us-east-1:
-      SPSLRHEL: ami-0bf453a3f805ec754
-      SPSLRHELBYOL: ami-0b37b748aa7d04908
+      SPSLRHEL: ami-09c5de5e043a82f07
+      SPSLRHELBYOL: ami-095908dd92a3380f1
     us-east-2:
-      SPSLRHEL: ami-06c4b7a0f2e81c3fa
-      SPSLRHELBYOL: ami-0bf20e0cbbc631ff9
+      SPSLRHEL: ami-0649e61b126948c04
+      SPSLRHELBYOL: ami-08ddb3ea0e5859783
     us-west-1:
-      SPSLRHEL: ami-0ed9bd0964a60fae2
-      SPSLRHELBYOL: ami-05ae01a676795e523
+      SPSLRHEL: ami-0f4c7897602b897bd
+      SPSLRHELBYOL: ami-079a49135fabb9bbf
     us-west-2:
-      SPSLRHEL: ami-03540f855708b82d6
-      SPSLRHELBYOL: ami-049f44917adb3a215
+      SPSLRHEL: ami-041ceaa2e55a5deee
+      SPSLRHELBYOL: ami-03426fd08592fe41d
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-ia']
   HomeProvisionedIopsCondition: !Equals [!Ref HomeVolumeType, "Provisioned IOPS"]
@@ -767,7 +767,7 @@ Resources:
           hostnamectl set-hostname --static ${SPSLInstanceNamePrefix}01
           echo '${NewRootPassword}' | passwd --stdin root
           cd /tmp
-          wget http://stedolan.github.io/jq/download/linux64/jq -O /usr/local/bin/jq > /dev/null 2>&1
+          wget https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 -O /usr/local/bin/jq > /dev/null 2>&1
           chmod 755 /usr/local/bin/jq
           wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm > /dev/null 2>&1
           rpm -ivh /tmp/amazon-ssm-agent.rpm > /dev/null 2>&1
@@ -869,7 +869,7 @@ Resources:
           hostnamectl set-hostname --static ${SPSLInstanceNamePrefix}02
           echo '${NewRootPassword}' | passwd --stdin root
           cd /tmp
-          wget http://stedolan.github.io/jq/download/linux64/jq -O /usr/local/bin/jq > /dev/null 2>&1
+          wget https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 -O /usr/local/bin/jq > /dev/null 2>&1
           chmod 755 /usr/local/bin/jq
           wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm > /dev/null 2>&1
           rpm -ivh /tmp/amazon-ssm-agent.rpm > /dev/null 2>&1
@@ -895,7 +895,7 @@ Resources:
               QSS3BucketRegion=${QSS3BucketRegion}, \
               QSS3KeyPrefix=${QSS3KeyPrefix}, \
               StackName=${AWS::StackName}, \
-              AutomationAssumeRole=arn:aws:iam::${AWS::AccountId}:role/${InstanceRole}" >> /var/log/cloud-init.log
+              AutomationAssumeRole=arn:aws:iam::${AWS::AccountId}:role/${InstanceRole}" 2>&1 >> /var/log/cloud-init.log
   QuickStartLogs:
     Type: AWS::Logs::LogGroup
     Properties: 
@@ -1035,7 +1035,7 @@ Resources:
             Parameters:
               sourceType: "S3"
               sourceInfo: '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.amazonaws.com/{{QSS3KeyPrefix}}scripts/InstallLicAndStartLK.pl"}'
-              commandLine: "./InstallLicAndStartLK.pl -s {{StackName}} -r {{global:REGION}} >> /var/log/cloud-init.log"
+              commandLine: "./InstallLicAndStartLK.pl -s {{StackName}} -r {{global:REGION}} 2>&1  >> /var/log/cloud-init.log"
         - name: "createCommpathsSPSL01"
           action: "aws:runCommand"
           onFailure: "step:signalfailure"
@@ -1050,7 +1050,7 @@ Resources:
             Parameters:
               sourceType: "S3"
               sourceInfo: '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.amazonaws.com/{{QSS3KeyPrefix}}scripts/CreateCommPath.pl"}'
-              commandLine: "sleep 60; ./CreateCommPath.pl -l {{Node1PrivateIP}} -r {{Node2PrivateIP}} -s {{SPSLNode2Hostname}} >> /var/log/cloud-init.log"
+              commandLine: "sleep 60; ./CreateCommPath.pl -l {{Node1PrivateIP}} -r {{Node2PrivateIP}} -s {{SPSLNode2Hostname}} 2>&1 >> /var/log/cloud-init.log;"
         - name: "createCommpathsSPSL02"
           action: "aws:runCommand"
           onFailure: "step:signalfailure"
@@ -1065,7 +1065,7 @@ Resources:
             Parameters:
               sourceType: "S3"
               sourceInfo: '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.amazonaws.com/{{QSS3KeyPrefix}}scripts/CreateCommPath.pl"}'
-              commandLine: "./CreateCommPath.pl -l {{Node2PrivateIP}} -r {{Node1PrivateIP}} -s {{SPSLNode1Hostname}} >> /var/log/cloud-init.log"
+              commandLine: "./CreateCommPath.pl -l {{Node2PrivateIP}} -r {{Node1PrivateIP}} -s {{SPSLNode1Hostname}} 2>&1 >> /var/log/cloud-init.log;"
         - name: "CreateMirrors"
           action: "aws:runCommand"
           onFailure: "step:signalfailure"
@@ -1080,9 +1080,7 @@ Resources:
             Parameters:
               sourceType: "S3"
               sourceInfo: '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.amazonaws.com/{{QSS3KeyPrefix}}scripts/CreateMirrorHierarchy.pl"}'
-              commandLine:
-                - |
-                   while ! ./CreateMirrorHierarchy.pl -l /dev/xvdca -r /dev/xvdca >> /var/log/cloud-init.log; do sleep 10; done
+              commandLine: "while ! ./CreateMirrorHierarchy.pl -l /dev/xvdca -r /dev/xvdca 2>&1 >> /var/log/cloud-init.log; do sleep 10; done" 
         # If all steps complete successfully signals CFN of Success
         - name: "signalsuccess"
           action: "aws:executeAwsApi"


### PR DESCRIPTION
Included some fixes to accomodate the following:

Creating the cluster nodes via updated AMIs

Creating mirrors more reliably

Starting LifeKeeper in PAYG scenarioes and avoiding failures due to a missing license URL 

Internal testing has passed following successful deployment and check of cluster nodes